### PR TITLE
Feature/pci 4 compatibility

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -1,0 +1,138 @@
+name: Integration Test
+
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  integration-test:
+    runs-on: "ubuntu-latest"
+
+    # Only run integration tests on feature branches. Simple documentation updates, formatting can be ignored
+    if: contains(github.head_ref, 'feature')
+    name: ${{ matrix.job_title }}
+    strategy:
+      fail-fast: true
+      matrix:
+        magento:
+          [
+            "magento/project-community-edition:>=2.4.6 <2.4.7",
+            "magento/project-community-edition:>=2.4.7 <2.4.8",
+          ]
+        include:
+          - magento: magento/project-community-edition:>=2.4.6 <2.4.7
+            php: 8.2
+            composer: 2.2
+            mysql: "mysql:8.0"
+            elasticsearch: "elasticsearch:7.17.9"
+            rabbitmq: "rabbitmq:3.12-management"
+            redis: "redis:7.0"
+            job_title: "2.4.6"
+
+          - magento: magento/project-community-edition:>=2.4.7 <2.4.8
+            php: 8.3
+            composer: 2.7
+            mysql: "mariadb:10.6"
+            elasticsearch: "elasticsearch:7.17.9"
+            rabbitmq: "rabbitmq:3.12-management"
+            redis: "redis:7.2"
+            job_title: "2.4.7"
+
+    services:
+      elasticsearch:
+        image: ${{ matrix.elasticsearch }}
+        env:
+          discovery.type: single-node
+        options: >-
+          --health-cmd "curl http://localhost:9200/_cluster/health"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 10
+        ports:
+          - 9200:9200
+
+      mysql:
+        image: ${{ matrix.mysql }}
+        env:
+          MYSQL_DATABASE: magento_integration_tests
+          MYSQL_USER: user
+          MYSQL_PASSWORD: password
+          MYSQL_ROOT_PASSWORD: rootpassword
+        ports:
+          - 3306:3306
+        options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3
+
+      rabbitmq:
+        image: ${{ matrix.rabbitmq }}
+        env:
+          RABBITMQ_DEFAULT_USER: guest
+          RABBITMQ_DEFAULT_PASS: guest
+        ports:
+          - 5672:5672
+          - 15672:15672
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set PHP Version
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php }}
+          tools: composer:2
+          coverage: none
+
+      - run: composer create-project --repository-url="https://mirror.mage-os.org/" "${{ matrix.magento }}" ../magento2 --no-install
+        shell: bash
+        env:
+          COMPOSER_AUTH: ""
+        name: Create Magento ${{ matrix.magento }} Project
+
+      - uses: graycoreio/github-actions-magento2/get-magento-version@main
+        id: magento-version
+        with:
+          working-directory: "../magento2"
+
+      - name: Get Composer Cache Directory
+        shell: bash
+        working-directory: "../magento2"
+        id: composer-cache
+        run: |
+          echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
+
+      - name: "Cache Composer Packages"
+        uses: actions/cache@v4
+        with:
+          key: "composer | v5 | '' | ${{ hashFiles('composer.lock') }}"
+          path: ${{ steps.composer-cache.outputs.dir }}
+
+      - run: composer config repositories.local path $GITHUB_WORKSPACE
+        name: Add Github Repo for Testing
+        working-directory: "../magento2"
+        shell: bash
+
+      - run: |
+          composer config --no-interaction allow-plugins.dealerdirect/phpcodesniffer-composer-installer true
+          composer config --no-interaction allow-plugins.laminas/laminas-dependency-plugin true
+          composer config --no-interaction allow-plugins.magento/* true
+        name: Fixup Composer Plugins
+        working-directory: "../magento2"
+
+      - run: composer require aligent/magento2-pci-4-compatibility "@dev" --no-update && composer install
+        name: Require and attempt install
+        working-directory: "../magento2"
+        shell: bash
+        env:
+          COMPOSER_CACHE_DIR: ${{ steps.composer-cache.outputs.dir }}
+          COMPOSER_AUTH: ${{ secrets.composer_auth }}
+
+      - name: Replace Configuration Settings for env
+        working-directory: ../magento2/dev/tests/integration
+        run: |
+          sed -i "s/'db-host' => 'localhost'/'db-host' => '127.0.0.1'/" etc/install-config-mysql.php.dist
+          sed -i "s/'db-user' => 'root'/'db-user' => 'user'/" etc/install-config-mysql.php.dist
+          sed -i "s/'db-password' => '123123q'/'db-password' => 'password'/" etc/install-config-mysql.php.dist
+          sed -i "s/'elasticsearch-host' => 'localhost'/'elasticsearch-host' => '127.0.0.1'/" etc/install-config-mysql.php.dist
+          sed -i "s/'amqp-host' => 'localhost'/'amqp-host' => '127.0.0.1'/" etc/install-config-mysql.php.dist
+
+      - run: ../../../vendor/bin/phpunit ../../../vendor/aligent/magento2-pci-4-compatibility/Test/Integration
+        working-directory: ../magento2/dev/tests/integration
+        name: Run Integration Tests

--- a/Console/DisableInactiveAccounts.php
+++ b/Console/DisableInactiveAccounts.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+namespace Aligent\Pci4Compatibility\Console;
+
+use Aligent\Pci4Compatibility\Model\DisableInactiveAdminAccounts;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class DisableInactiveAccounts extends Command
+{
+
+    /**
+     * @param DisableInactiveAdminAccounts $disableInactiveAdminAccounts
+     * @param string|null $name
+     */
+    public function __construct(
+        private readonly DisableInactiveAdminAccounts $disableInactiveAdminAccounts,
+        ?string $name = null
+    ) {
+        parent::__construct($name);
+    }
+
+    protected function configure(): void
+    {
+        $this->setName('aligent:pci4:disable-inactive-accounts');
+        $this->setDescription('Disable admin accounts with 90 days of inactivity');
+        parent::configure();
+    }
+
+    /**
+     * Disable admin accounts with 90 days of inactivity
+     *
+     * Used to be able to satisfy PCI DSS 4.0.1 requirement 8.2.6
+     *
+     * @param InputInterface $input
+     * @param OutputInterface $output
+     * @return void
+     */
+    protected function execute(InputInterface $input, OutputInterface $output): void
+    {
+        $output->writeln(__("Disabling any admin accounts with 90 days of inactivity"));
+        $this->disableInactiveAdminAccounts->execute();
+        $output->writeln(__("Disabling of accounts complete"));
+    }
+}

--- a/Cron/DisableInactiveAccounts.php
+++ b/Cron/DisableInactiveAccounts.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+namespace Aligent\Pci4Compatibility\Cron;
+
+use Aligent\Pci4Compatibility\Model\DisableInactiveAdminAccounts;
+
+class DisableInactiveAccounts
+{
+
+    /**
+     * @param DisableInactiveAdminAccounts $inactiveUsers
+     */
+    public function __construct(
+        private readonly DisableInactiveAdminAccounts $inactiveUsers,
+    ) {
+    }
+
+    /**
+     * Cron job that simply runs service to disable inactive admin accounts.
+     *
+     * This is to satisfy PCI DSS 4.0.1 requirement 8.2.6
+     *
+     * @return void
+     */
+    public function execute(): void
+    {
+        $this->inactiveUsers->execute();
+    }
+}

--- a/Model/DisableInactiveAdminAccounts.php
+++ b/Model/DisableInactiveAdminAccounts.php
@@ -42,7 +42,6 @@ class DisableInactiveAdminAccounts
             $currentDateUtc = $currentDate->setTimezone(new \DateTimeZone('UTC'));
             $utcDateTime = $currentDateUtc->sub(new DateInterval('P' . self::INACTIVE_DAYS . 'D'));
             $utcDateTime = $utcDateTime->format('Y-m-d H:i:s');
-            echo("UTC Datetime: " . $utcDateTime . "\n");
         } catch (\Exception $e) {
             $this->logger->critical(
                 __METHOD__ . ': Could not get cutoff date for inactivity: ' . $e->getMessage(),

--- a/Model/DisableInactiveAdminAccounts.php
+++ b/Model/DisableInactiveAdminAccounts.php
@@ -1,7 +1,7 @@
 <?php
 
 declare(strict_types=1);
-namespace Model;
+namespace Aligent\Pci4Compatibility\Model;
 
 use DateInterval;
 use Magento\Framework\Stdlib\DateTime\TimezoneInterface;
@@ -11,7 +11,7 @@ use Magento\User\Model\ResourceModel\User\CollectionFactory as UserCollectionFac
 use Magento\User\Model\User;
 use Psr\Log\LoggerInterface;
 
-class InvalidateInactiveUsers
+class DisableInactiveAdminAccounts
 {
     private const INACTIVE_DAYS = 90;
 

--- a/Model/InvalidateInactiveUsers.php
+++ b/Model/InvalidateInactiveUsers.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+namespace Model;
+
+use DateInterval;
+use Magento\Framework\Stdlib\DateTime\TimezoneInterface;
+use Magento\User\Model\ResourceModel\User as UserResource;
+use Magento\User\Model\ResourceModel\User\Collection as UserCollection;
+use Magento\User\Model\ResourceModel\User\CollectionFactory as UserCollectionFactory;
+use Magento\User\Model\User;
+use Psr\Log\LoggerInterface;
+
+class InvalidateInactiveUsers
+{
+    private const INACTIVE_DAYS = 90;
+
+    /**
+     * @param TimezoneInterface $localeDate
+     * @param UserCollectionFactory $userCollectionFactory
+     * @param UserResource $userResource
+     * @param LoggerInterface $logger
+     */
+    public function __construct(
+        private readonly TimezoneInterface $localeDate,
+        private readonly UserCollectionFactory $userCollectionFactory,
+        private readonly UserResource $userResource,
+        private readonly LoggerInterface $logger
+    ) {
+    }
+
+    /**
+     * Sets the account of any admin user with no login in the last 90 days to inactive.
+     *
+     * This is used to be able to satisfy PCI DSS 4.0.1 requirement 8.2.6
+     *
+     * @return void
+     */
+    public function execute(): void
+    {
+        try {
+            $currentDate = $this->localeDate->date()->sub(new DateInterval('P' . self::INACTIVE_DAYS . 'D'));
+            $utcDateTime = $this->localeDate->convertConfigTimeToUtc($currentDate);
+        } catch (\Exception $e) {
+            $this->logger->critical(
+                __METHOD__ . ': Could not get cutoff date for inactivity: ' . $e->getMessage(),
+                ['exception' => $e]
+            );
+            return;
+        }
+
+        /** @var UserCollection $userCollection */
+        $userCollection = $this->userCollectionFactory->create();
+        // don't need to disable accounts that are already disabled
+        $userCollection->addFieldToFilter('status', '1');
+        $userCollection->addFieldToFilter('logdate', ['lt' => $utcDateTime]);
+        $users = $userCollection->getItems();
+        foreach ($users as $user) {
+            /** @var User $user */
+            $user->setData('status', 0);
+            $username = $user->getData('username');
+            try {
+                $this->userResource->save($user);
+            } catch (\Exception $e) {
+                $this->logger->critical(
+                    __METHOD__ . ": Could not disable account for user {$username} :" . $e->getMessage(),
+                    ['exception' => $e]
+                );
+            }
+        }
+    }
+}

--- a/Plugin/Model/ReplacePasswordValidationRules.php
+++ b/Plugin/Model/ReplacePasswordValidationRules.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+namespace Aligent\Pci4Compatibility\Plugin\Model;
+
+use Magento\Framework\Validator\DataObject;
+use Magento\Framework\Validator\NotEmpty;
+use Magento\Framework\Validator\Regex;
+use Magento\Framework\Validator\StringLength;
+use Magento\User\Model\UserValidationRules;
+
+class ReplacePasswordValidationRules
+{
+
+    private const MIN_PASSWORD_LENGTH = 12;
+
+    /**
+     * Updates the requirements for admin passwords so that the minimum length is 12 characters
+     *
+     * @param UserValidationRules $subject
+     * @param callable $proceed
+     * @param DataObject $validator
+     * @return DataObject
+     */
+    public function aroundAddPasswordRules(
+        UserValidationRules $subject,
+        callable $proceed,
+        DataObject $validator
+    ): DataObject {
+        $passwordNotEmpty = new NotEmpty();
+        $passwordNotEmpty->setMessage(__('Password is required field.'), NotEmpty::IS_EMPTY);
+        $passwordLength = new StringLength(['min' => self::MIN_PASSWORD_LENGTH, 'encoding' => 'UTF-8']);
+        $passwordLength->setMessage(
+            __('Your password must be at least %1 characters.', self::MIN_PASSWORD_LENGTH),
+            StringLength::TOO_SHORT
+        );
+        $passwordChars = new Regex('/[a-z].*\d|\d.*[a-z]/iu');
+        $passwordChars->setMessage(
+            __('Your password must include both numeric and alphabetic characters.'),
+            Regex::NOT_MATCH
+        );
+        $validator->addRule($passwordNotEmpty,'password');
+        $validator->addRule($passwordLength, 'password');
+        $validator->addRule($passwordChars,'password');
+
+        return $validator;
+    }
+}

--- a/Test/Integration/DisableInactiveAdminAccountsTest.php
+++ b/Test/Integration/DisableInactiveAdminAccountsTest.php
@@ -1,0 +1,105 @@
+<?php
+
+declare(strict_types=1);
+namespace Aligent\Pci4Compatibility\Test\Integration;
+
+use Aligent\Pci4Compatibility\Model\DisableInactiveAdminAccounts;
+use Magento\TestFramework\ObjectManager;
+use Magento\User\Model\ResourceModel\User as UserResource;
+use PHPUnit\Framework\TestCase;
+
+class DisableInactiveAdminAccountsTest extends TestCase
+{
+
+    /**
+     * @var DisableInactiveAdminAccounts|null
+     */
+    private ?DisableInactiveAdminAccounts $disableInactiveAdminAccounts = null;
+    /**
+     * @var UserResource|null
+     */
+    private ?UserResource $userResource = null;
+
+    /**
+     * @inheritDoc
+     */
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $objectManager = ObjectManager::getInstance();
+        $this->disableInactiveAdminAccounts = $objectManager->create(DisableInactiveAdminAccounts::class);
+        $this->userResource = $objectManager->create(UserResource::class);
+    }
+
+    /**
+     * Ensure that accounts not accessed in 90 days are disabled
+     *
+     * @magentoDataFixture Aligent_Pci4Compatibility::Test/_files/inactive_admin_account.php
+     *
+     * @return void
+     * @throws \Exception
+     */
+    public function testInactiveAccountIsDisabled(): void
+    {
+        // Trigger the DisableInactiveAdminAccounts functionality
+        $this->disableInactiveAdminAccounts->execute();
+
+        $userData = $this->userResource->loadByUsername('inactiveAdmin1');
+        $status = (int)($userData['is_active'] ?? 1);
+        $this->assertEquals(0, $status, 'Inactive admin account inactiveAdmin1 was not disabled.');
+    }
+
+    /**
+     * Ensure that accounts not used in 90 days since creation are disabled
+     *
+     * @magentoDataFixture Aligent_Pci4Compatibility::Test/_files/unused_inactive_admin_account.php
+     *
+     * @return void
+     * @throws \Exception
+     */
+    public function testUnusedInactiveAccountIsDisabled(): void
+    {
+        // Trigger the DisableInactiveAdminAccounts functionality
+        $this->disableInactiveAdminAccounts->execute();
+
+        $userData = $this->userResource->loadByUsername('inactiveAdmin2');
+        $status = (int)($userData['is_active'] ?? 1);
+        $this->assertEquals(0, $status, 'Inactive admin account inactiveAdmin2 was not disabled.');
+    }
+
+    /**
+     * Ensure that accounts accessed in 90 days are not disabled
+     *
+     * @magentoDataFixture Aligent_Pci4Compatibility::Test/_files/active_admin_account.php
+     *
+     * @return void
+     * @throws \Exception
+     */
+    public function testActiveAccountIsNotDisabled(): void
+    {
+        // Trigger the DisableInactiveAdminAccounts functionality
+        $this->disableInactiveAdminAccounts->execute();
+
+        $userData = $this->userResource->loadByUsername('activeAdmin1');
+        $status = (int)($userData['is_active'] ?? 0);
+        $this->assertEquals(1, $status, 'Active admin account activeAdmin1 was disabled.');
+    }
+
+    /**
+     * Ensure that accounts created less than 90 days ago are not disabled
+     *
+     * @magentoDataFixture Aligent_Pci4Compatibility::Test/_files/unused_active_admin_account.php
+     *
+     * @return void
+     * @throws \Exception
+     */
+    public function testUnusedActiveAccountIsNotDisabled(): void
+    {
+        // Trigger the DisableInactiveAdminAccounts functionality
+        $this->disableInactiveAdminAccounts->execute();
+
+        $userData = $this->userResource->loadByUsername('activeAdmin2');
+        $status = (int)($userData['is_active'] ?? 0);
+        $this->assertEquals(1, $status, 'Active admin account activeAdmin2 was disabled.');
+    }
+}

--- a/Test/Integration/PasswordValidationTest.php
+++ b/Test/Integration/PasswordValidationTest.php
@@ -1,0 +1,81 @@
+<?php
+
+declare(strict_types=1);
+namespace Aligent\Pci4Compatibility\Test\Integration;
+
+use Magento\Framework\Exception\AlreadyExistsException;
+use Magento\Framework\Validator\Exception as ValidatorException;
+use Magento\TestFramework\ObjectManager;
+use Magento\User\Model\ResourceModel\User as UserResource;
+use Magento\User\Model\UserFactory;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @magentoAppArea adminhtml
+ */
+class PasswordValidationTest extends TestCase
+{
+
+    private const VALID_PASSWORD = 'password1234';
+    private const INVALID_PASSWORD = 'password123';
+
+    private ?UserFactory $userFactory = null;
+    private ?UserResource $userResource = null;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $objectManager = ObjectManager::getInstance();
+        $this->userFactory = $objectManager->create(UserFactory::class);
+        $this->userResource = $objectManager->create(UserResource::class);
+    }
+
+    /**
+     * Test that a user can be created with a password of 12 characters
+     *
+     * @return void
+     * @throws AlreadyExistsException
+     */
+    public function testValidPasswordLength()
+    {
+        $user = $this->userFactory->create();
+        $user->setData(
+            [
+                'firstname' => 'Admin',
+                'lastname' => 'User',
+                'username' => 'adminUserWithValidPassword',
+                'password' => self::VALID_PASSWORD,
+                'email' => 'adminUserWithValidPassword@example.com',
+                'role_id' => 1,
+                'is_active' => 1
+            ]
+        );
+        $this->userResource->save($user);
+        $this->assertNotEmpty($user->getId());
+    }
+
+    /**
+     * Test that a user cannot be created with a password of less than 12 characters
+     *
+     * @return void
+     * @throws AlreadyExistsException
+     */
+    public function testInvalidPasswordLength()
+    {
+        $user = $this->userFactory->create();
+        $user->setData(
+            [
+                'firstname' => 'Admin',
+                'lastname' => 'User',
+                'username' => 'adminUserWithValidPassword',
+                'password' => self::INVALID_PASSWORD,
+                'email' => 'adminUserWithValidPassword@example.com',
+                'role_id' => 1,
+                'is_active' => 1
+            ]
+        );
+        $this->expectException(ValidatorException::class);
+        $this->expectExceptionMessage('Your password must be at least 12 characters.');
+        $this->userResource->save($user);
+    }
+}

--- a/Test/_files/active_admin_account.php
+++ b/Test/_files/active_admin_account.php
@@ -1,0 +1,24 @@
+<?php
+declare(strict_types=1);
+
+use Magento\TestFramework\Helper\Bootstrap;
+use Magento\User\Model\ResourceModel\User as UserResource;
+use Magento\User\Model\User;
+
+$objectManager = Bootstrap::getObjectManager();
+
+$userData = [
+    'firstname' => 'Active',
+    'lastname' => 'Admin1',
+    'username' => 'activeAdmin1',
+    'password' => \Magento\TestFramework\Bootstrap::ADMIN_PASSWORD,
+    'email' => 'activeUser1@example.com',
+    'role_id' => 1,
+    'is_active' => 1,
+    'logdate' => date('Y-m-d H:i:s', strtotime('-89 days'))
+];
+
+$model = $objectManager->create(User::class);
+$model->setData($userData);
+$userResource = $objectManager->create(UserResource::class);
+$userResource->save($model);

--- a/Test/_files/active_admin_account_rollback.php
+++ b/Test/_files/active_admin_account_rollback.php
@@ -1,0 +1,16 @@
+<?php
+declare(strict_types=1);
+
+use Magento\TestFramework\Helper\Bootstrap;
+use Magento\User\Model\ResourceModel\User as UserResource;
+use Magento\User\Model\User;
+
+$objectManager = Bootstrap::getObjectManager();
+
+$user = $objectManager->create(User::class);
+$userResource = $objectManager->create(UserResource::class);
+
+$user->loadByUsername('activeAdmin1');
+if ($user->getId()) {
+    $userResource->delete($user);;
+}

--- a/Test/_files/inactive_admin_account.php
+++ b/Test/_files/inactive_admin_account.php
@@ -2,8 +2,8 @@
 declare(strict_types=1);
 
 use Magento\TestFramework\Helper\Bootstrap;
-use Magento\User\Model\User;
 use Magento\User\Model\ResourceModel\User as UserResource;
+use Magento\User\Model\User;
 
 $objectManager = Bootstrap::getObjectManager();
 

--- a/Test/_files/inactive_admin_account.php
+++ b/Test/_files/inactive_admin_account.php
@@ -1,0 +1,24 @@
+<?php
+declare(strict_types=1);
+
+use Magento\TestFramework\Helper\Bootstrap;
+use Magento\User\Model\User;
+use Magento\User\Model\ResourceModel\User as UserResource;
+
+$objectManager = Bootstrap::getObjectManager();
+
+$userData = [
+    'firstname' => 'Inactive',
+    'lastname' => 'Admin1',
+    'username' => 'inactiveAdmin1',
+    'password' => \Magento\TestFramework\Bootstrap::ADMIN_PASSWORD,
+    'email' => 'inactiveUser1@example.com',
+    'role_id' => 1,
+    'is_active' => 1,
+    'logdate' => date('Y-m-d H:i:s', strtotime('-90 days -1 hour')),
+];
+
+$model = $objectManager->create(User::class);
+$model->setData($userData);
+$userResource = $objectManager->create(UserResource::class);
+$userResource->save($model);

--- a/Test/_files/inactive_admin_account_rollback.php
+++ b/Test/_files/inactive_admin_account_rollback.php
@@ -1,0 +1,17 @@
+<?php
+declare(strict_types=1);
+
+use Magento\TestFramework\Helper\Bootstrap;
+use Magento\User\Model\ResourceModel\User as UserResource;
+use Magento\User\Model\User;
+
+$objectManager = Bootstrap::getObjectManager();
+
+$user = $objectManager->create(User::class);
+$userResource = $objectManager->create(UserResource::class);
+
+$user->loadByUsername('inactiveAdmin1');
+if ($user->getId()) {
+    $userResource->delete($user);;
+}
+

--- a/Test/_files/unused_active_admin_account.php
+++ b/Test/_files/unused_active_admin_account.php
@@ -1,0 +1,25 @@
+<?php
+declare(strict_types=1);
+
+use Magento\TestFramework\Helper\Bootstrap;
+use Magento\User\Model\ResourceModel\User as UserResource;
+use Magento\User\Model\User;
+
+$objectManager = Bootstrap::getObjectManager();
+
+$userData = [
+    'firstname' => 'Active',
+    'lastname' => 'Admin2',
+    'username' => 'activeAdmin2',
+    'password' => \Magento\TestFramework\Bootstrap::ADMIN_PASSWORD,
+    'email' => 'activeUser2@example.com',
+    'role_id' => 1,
+    'is_active' => 1,
+    'created' => date('Y-m-d H:i:s', strtotime('-89 days')),
+    'logdate' => null,
+];
+
+$model = $objectManager->create(User::class);
+$model->setData($userData);
+$userResource = $objectManager->create(UserResource::class);
+$userResource->save($model);

--- a/Test/_files/unused_active_admin_account_rollback.php
+++ b/Test/_files/unused_active_admin_account_rollback.php
@@ -1,0 +1,16 @@
+<?php
+declare(strict_types=1);
+
+use Magento\TestFramework\Helper\Bootstrap;
+use Magento\User\Model\ResourceModel\User as UserResource;
+use Magento\User\Model\User;
+
+$objectManager = Bootstrap::getObjectManager();
+
+$user = $objectManager->create(User::class);
+$userResource = $objectManager->create(UserResource::class);
+
+$user->loadByUsername('activeAdmin2');
+if ($user->getId()) {
+    $userResource->delete($user);;
+}

--- a/Test/_files/unused_inactive_admin_account.php
+++ b/Test/_files/unused_inactive_admin_account.php
@@ -1,0 +1,25 @@
+<?php
+declare(strict_types=1);
+
+use Magento\TestFramework\Helper\Bootstrap;
+use Magento\User\Model\ResourceModel\User as UserResource;
+use Magento\User\Model\User;
+
+$objectManager = Bootstrap::getObjectManager();
+
+$userData = [
+    'firstname' => 'Inactive',
+    'lastname' => 'Admin2',
+    'username' => 'inactiveAdmin2',
+    'password' => \Magento\TestFramework\Bootstrap::ADMIN_PASSWORD,
+    'email' => 'inactiveUser2@example.com',
+    'role_id' => 1,
+    'is_active' => 1,
+    'created' => date('Y-m-d H:i:s', strtotime('-90 days -1 hour')),
+    'logdate' => null
+];
+
+$model = $objectManager->create(User::class);
+$model->setData($userData);
+$userResource = $objectManager->create(UserResource::class);
+$userResource->save($model);

--- a/Test/_files/unused_inactive_admin_account_rollback.php
+++ b/Test/_files/unused_inactive_admin_account_rollback.php
@@ -1,0 +1,18 @@
+<?php
+declare(strict_types=1);
+
+use Magento\TestFramework\Helper\Bootstrap;
+use Magento\User\Model\ResourceModel\User as UserResource;
+use Magento\User\Model\User;
+
+$objectManager = Bootstrap::getObjectManager();
+
+$objectManager = Bootstrap::getObjectManager();
+
+$user = $objectManager->create(User::class);
+$userResource = $objectManager->create(UserResource::class);
+
+$user->loadByUsername('inactiveAdmin2');
+if ($user->getId()) {
+    $userResource->delete($user);;
+}

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,19 @@
+{
+    "name": "aligent/magento2-pci-4-compatibility",
+    "description": "Provide compatibility with PCI DSS 4.0 requirements",
+    "require": {
+        "php": "^8.2.0|^8.3.0"
+    },
+    "type": "magento2-module",
+    "license": [
+        "MIT"
+    ],
+    "autoload": {
+        "files": [
+            "registration.php"
+        ],
+        "psr-4": {
+            "Aligent\\Pci4Compatibility\\": ""
+        }
+    }
+}

--- a/etc/adminhtml/di.xml
+++ b/etc/adminhtml/di.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0"?>
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:ObjectManager/etc/config.xsd">
+    <type name="Magento\Framework\Console\CommandListInterface">
+        <arguments>
+            <argument name="commands" xsi:type="array">
+                <item name="disableInactiveAdminUsers" xsi:type="object">Aligent\Pci4Compatibility\Console\DisableInactiveAccounts</item>
+            </argument>
+        </arguments>
+    </type>
+    <type name="Magento\User\Model\UserValidationRules">
+        <plugin name="replacePasswordRules" type="Aligent\Pci4Compatibility\Plugin\Model\ReplacePasswordValidationRules"/>
+    </type>
+</config>

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -7,6 +7,14 @@
                     <comment>Please enter at least 60 and at most 900 (15 minutes).</comment>
                     <validate>required-entry validate-digits validate-digits-range digits-range-60-900</validate>
                 </field>
+                <field id="lockout_failures">
+                    <comment>Must be less than or equal to 10</comment>
+                    <validate>required-entry validate-digits digits-range 1-10</validate>
+                </field>
+                <field id="lockout_threshold" translate="label comment">
+                    <comment>Must be at least 30 minutes</comment>
+                    <validate>required-entry validate-digits digits-range-30-525600</validate>
+                </field>
             </group>
         </section>
     </system>

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0"?>
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Config:etc/system_file.xsd">
+    <system>
+        <section id="admin">
+            <group id="security">
+                <field id="session_lifetime">
+                    <comment>Please enter at least 60 and at most 900 (15 minutes).</comment>
+                    <validate>required-entry validate-digits validate-digits-range digits-range-60-900</validate>
+                </field>
+            </group>
+        </section>
+    </system>
+</config>

--- a/etc/crontab.xml
+++ b/etc/crontab.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0"?>
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Cron:etc/crontab.xsd">
+    <group id="default">
+        <job name="aligent_disable_inactive_accounts" instance="Aligent\Pci4Compatibility\Cron\DisableInactiveAccounts"
+             method="execute">
+            <schedule>30 1 * * *</schedule>
+        </job>
+    </group>
+</config>

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0"?>
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:ObjectManager/etc/config.xsd">
+    <type name="Magento\Framework\Console\CommandListInterface">
+        <arguments>
+            <argument name="commands" xsi:type="array">
+                <item name="disableInactiveAdminUsers" xsi:type="object">Aligent\Pci4Compatibility\Console\DisableInactiveAccounts</item>
+            </argument>
+        </arguments>
+    </type>
+</config>

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0"?>
+
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
+    <module name="Aligent_Pci4Compatibility" />
+</config>

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -1,5 +1,9 @@
 <?xml version="1.0"?>
 
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="Aligent_Pci4Compatibility" />
+    <module name="Aligent_Pci4Compatibility">
+        <sequence>
+            <module name="Magento_Backend"/>
+        </sequence>
+    </module>
 </config>

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -4,6 +4,7 @@
     <module name="Aligent_Pci4Compatibility">
         <sequence>
             <module name="Magento_Backend"/>
+            <module name="Magento_User"/>
         </sequence>
     </module>
 </config>

--- a/registration.php
+++ b/registration.php
@@ -1,0 +1,6 @@
+<?php
+declare(strict_types=1);
+
+use Magento\Framework\Component\ComponentRegistrar;
+
+ComponentRegistrar::register(ComponentRegistrar::MODULE, 'Aligent_Pci4Compatibility', __DIR__);

--- a/view/adminhtml/requirejs-config.js
+++ b/view/adminhtml/requirejs-config.js
@@ -1,0 +1,9 @@
+var config = {
+    config: {
+        mixins: {
+            'mage/validation': {
+                'Aligent_Pci4Compatibility/js/system/config/validator-mixin': true
+            },
+        }
+    }
+};

--- a/view/adminhtml/web/js/system/config/validator-mixin.js
+++ b/view/adminhtml/web/js/system/config/validator-mixin.js
@@ -1,0 +1,33 @@
+define([
+    'jquery'
+], function ($) {
+    'use strict';
+
+    return function (target) {
+        $.validator.addMethod(
+            'validate-admin-password',
+            function (v) {
+                var pass;
+
+                if (v == null) {
+                    return false;
+                }
+                // strip leading and trailing spaces
+                pass = v.trim();
+                // password is not being changed
+                if (pass.length === 0) {
+                    return true;
+                }
+
+                if (!/[a-z]/i.test(v) || !/[0-9]/.test(v)) {
+                    return false;
+                }
+
+                return pass.length >= 12;
+            },
+            $.mage.__('Please enter 12 or more characters, using both numeric and alphabetic.')
+        );
+
+        return target;
+    };
+});


### PR DESCRIPTION
Handle the various requirements for PCI DSS 4.0 that are not already covered OOTB:

### 8.2.6
 - Inactive user accounts are removed or disabled within 90 days of inactivity
    - A new cron job has been added to disable admin account that have not had a login in the last 90 days

### 8.2.8
 - If a user session has been idle for more than 15 minutes, the user is required to re-authenticate to re-activate the terminal or session.
    - Modify the validation of the configuration field so that 900 seconds (15 minutes) is the maximum allowed value.

### 8.3.4
 - Invalid authentication attempts are limited by:
    - Locking out the user ID after not more than 10 attempts.
      - Modify the validation of the configuration field so that 10 is the maximum allowed value.
    - Setting the lockout duration to a minimum of 30 minutes or until the user’s identity is confirmed.
      - Modify the validation of the configuration field so that 30 is the minimum allowed value.

### 8.3.6
 - If passwords/passphrases are used as authentication factors to meet Requirement 8.3.1, they meet the following minimum level of complexity:
   - A minimum length of 12 characters (or IF the system does not support 12 characters, a minimum length of eight characters).
     - Replace the OOTB password length rule (of 7 characters) with one requiring at least 12 characters.
   - Contain both numeric and alphabetic characters.
     - OOTB functionality