### PR TITLE
Add support for PHP 8.1 due to extended support of Magento 2.4.4 and 2.4.5

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -17,17 +17,37 @@ jobs:
       matrix:
         magento:
           [
+            "magento/project-community-edition:>=2.4.4 <2.4.5",
+            "magento/project-community-edition:>=2.4.5 <2.4.6",
             "magento/project-community-edition:>=2.4.6 <2.4.7",
             "magento/project-community-edition:>=2.4.7 <2.4.8",
           ]
         include:
+          - magento: magento/project-community-edition:>=2.4.4 <2.4.5
+            php: 8.1
+            composer: 2.2
+            mysql: "mariadb:10.5"
+            elasticsearch: "elasticsearch:7.17.9"
+            rabbitmq: "rabbitmq:3.9-management"
+            redis: "redis:7.2"
+            job_title: "2.4.4"
+
+          - magento: magento/project-community-edition:>=2.4.5 <2.4.6
+            php: 8.1
+            composer: 2.2
+            mysql: "mariadb:10.5"
+            elasticsearch: "elasticsearch:7.17.9"
+            rabbitmq: "rabbitmq:3.13-management"
+            redis: "redis:7.2"
+            job_title: "2.4.5"
+
           - magento: magento/project-community-edition:>=2.4.6 <2.4.7
             php: 8.2
             composer: 2.2
-            mysql: "mysql:8.0"
+            mysql: "mariadb:10.6"
             elasticsearch: "elasticsearch:7.17.9"
-            rabbitmq: "rabbitmq:3.12-management"
-            redis: "redis:7.0"
+            rabbitmq: "rabbitmq:3.13-management"
+            redis: "redis:7.2"
             job_title: "2.4.6"
 
           - magento: magento/project-community-edition:>=2.4.7 <2.4.8
@@ -35,7 +55,7 @@ jobs:
             composer: 2.7
             mysql: "mariadb:10.6"
             elasticsearch: "elasticsearch:7.17.9"
-            rabbitmq: "rabbitmq:3.12-management"
+            rabbitmq: "rabbitmq:3.13-management"
             redis: "redis:7.2"
             job_title: "2.4.7"
 

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "aligent/magento2-pci-4-compatibility",
     "description": "Provide compatibility with PCI DSS 4.0 requirements",
     "require": {
-        "php": "^8.2.0|^8.3.0"
+        "php": "^8.1.0|^8.2.0|^8.3.0"
     },
     "type": "magento2-module",
     "license": [


### PR DESCRIPTION
Adobe is offering extended support for Commerce versions 2.4.4 and 2.4.5 until after PCI DSS 4.0 becomes mandatory. As such, add support for PHP 8.1 (which both versions use) and add both versions to the integration test checks.