### PR TITLE
BEG-226 - Ensure session expiry modal is hidden on page load.

### DIFF
--- a/etc/adminhtml/routes.xml
+++ b/etc/adminhtml/routes.xml
@@ -1,9 +1,4 @@
 <?xml version="1.0"?>
-<!--
-/**
- * Copyright © Aligent. All rights reserved.
- */
--->
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:noNamespaceSchemaLocation="urn:magento:framework:App/etc/routes.xsd">
     <router id="admin">

--- a/view/adminhtml/templates/modal.phtml
+++ b/view/adminhtml/templates/modal.phtml
@@ -4,151 +4,39 @@ declare(strict_types=1);
 use Aligent\Pci4Compatibility\ViewModel\Modal;
 use Magento\Backend\Block\Template;
 use Magento\Framework\Escaper;
+use Magento\Framework\View\Helper\SecureHtmlRenderer;
 
 /**
  * @var Template $block
  * @var Escaper $escaper
+ * @var SecureHtmlRenderer $secureRenderer
  * @var Modal $viewModel
  */
 $viewModel = $block->getViewModel();
-$modalTimeout = $viewModel->getModalPopupTimeout();
 $sessionLifetime = $viewModel->getSessionLifetime();
 $extendSessionUrl = $viewModel->getExtendSessionUrl();
 
 ?>
 
 <div id="session-expire-warning-modal">
-    <p style="font-size:48px;color:#FF0000">&#x26A0;</p>
+    <p class="session-warning-icon">&#x26A0;</p>
     <p id="session-warning-message">
-        <?= __(
+        <?= /* @noEscape */ __(
                 'Your session will expire in one minute. ' .
                 'Please save your changes or extend your session to continue working.'
         ) ?>
     </p>
-    <input type="hidden" id="session-extend-url" value="<?= $escaper->escapeUrl($extendSessionUrl) ?>"/>
-    <input type="hidden" id="session-lifetime" value="<?= $escaper->escapeHtmlAttr((string)$sessionLifetime) ?>"/>
 </div>
+<?= /* @noEscape */ $secureRenderer->renderStyleAsTag('display:none', '#session-expire-warning-modal'); ?>
 
-<script>
-    require(
-        [
-            'jquery',
-            'Magento_Ui/js/modal/modal',
-            'mage/translate'
-        ],
-        function(
-            $,
-            modal,
-            $t
-        ) {
-            let sessionTimeoutHandle = null;
-            const sessionLifetime = parseInt($('#session-lifetime').val()) || 900;
-            const warningOffset = 60; // Show warning 60 seconds before expiry
-
-            /**
-             * Initialize and show the session expiry warning modal
-             */
-            function initSessionWarningModal() {
-                const options = {
-                    type: 'popup',
-                    innerScroll: true,
-                    title: $t('Session Expiring Soon'),
-                    modalClass: 'modal-admintimeout',
-                    buttons: [
-                        {
-                            text: $t('Extend Session'),
-                            class: 'action-primary',
-                            click: function () {
-                                extendSession(this);
-                            }
-                        },
-                        {
-                            text: $t('Close'),
-                            class: 'action-secondary',
-                            click: function () {
-                                this.closeModal();
-                            }
-                        }
-                    ]
-                };
-
-                modal(options, $('#session-expire-warning-modal'));
+<script type="text/x-magento-init">
+    {
+        "#session-expire-warning-modal": {
+            "Aligent_Pci4Compatibility/js/session-expiry-warning": {
+                "sessionLifetime": <?= /* @noEscape */ (int)$sessionLifetime ?>,
+                "extendSessionUrl": "<?= $escaper->escapeUrl($extendSessionUrl) ?>",
+                "formKey": "<?= $escaper->escapeJs($block->getFormKey()) ?>"
             }
-
-            /**
-             * Schedule the session warning modal to appear
-             */
-            function scheduleSessionWarning() {
-                // Clear any existing timeout
-                if (sessionTimeoutHandle) {
-                    clearTimeout(sessionTimeoutHandle);
-                }
-
-                // Calculate delay: (sessionLifetime - warningOffset) * 1000 milliseconds
-                const delay = (sessionLifetime - warningOffset) * 1000;
-
-                sessionTimeoutHandle = setTimeout(function() {
-                    $('#session-expire-warning-modal').modal('openModal');
-                }, delay);
-            }
-
-            /**
-             * Extend the admin session via AJAX
-             */
-            function extendSession(modalContext) {
-                const $message = $('#session-warning-message');
-                const originalMessage = $message.text();
-
-                // Show loading state
-                $message.text($t('Extending your session...'));
-
-                $.ajax({
-                    url: $('#session-extend-url').val(),
-                    type: 'POST',
-                    dataType: 'json',
-                    data: {
-                        form_key: window.FORM_KEY
-                    },
-                    success: function(response) {
-                        if (response.success) {
-                            // Show a success message
-                            $message.text($t('Session extended successfully!'));
-
-                            // Close modal after a short delay
-                            setTimeout(function() {
-                                modalContext.closeModal();
-                                $message.text(originalMessage);
-
-                                // Reschedule the warning modal
-                                scheduleSessionWarning();
-                            }, 1500);
-                        } else {
-                            // Show error message
-                            $message.text(response.message || $t('Failed to extend session. Please try again.'));
-
-                            // Restore the original message after delay
-                            setTimeout(function() {
-                                $message.text(originalMessage);
-                            }, 3000);
-                        }
-                    },
-                    error: function() {
-                        // Show error message
-                        $message.text($t('An error occurred. Please refresh the page.'));
-
-                        // Restore the original message after delay
-                        setTimeout(function() {
-                            $message.text(originalMessage);
-                        }, 3000);
-                    }
-                });
-            }
-
-            // Initialize on document ready
-            $(document).ready(function() {
-                initSessionWarningModal();
-                scheduleSessionWarning();
-            });
         }
-    );
+    }
 </script>

--- a/view/adminhtml/web/css/source/_module.less
+++ b/view/adminhtml/web/css/source/_module.less
@@ -1,0 +1,7 @@
+// Session expiry warning modal styles
+#session-expire-warning-modal {
+    .session-warning-icon {
+        font-size: 48px;
+        color: #ff0000;
+    }
+}

--- a/view/adminhtml/web/js/session-expiry-warning.js
+++ b/view/adminhtml/web/js/session-expiry-warning.js
@@ -1,0 +1,120 @@
+define([
+    'jquery',
+    'Magento_Ui/js/modal/modal',
+    'mage/translate'
+], function ($, modal, $t) {
+    'use strict';
+
+    return function (config, element) {
+        let sessionTimeoutHandle = null,
+            sessionLifetime = config.sessionLifetime || 900,
+            warningOffset = 60, // Show warning 60 seconds before expiry
+            extendSessionUrl = config.extendSessionUrl,
+            formKey = config.formKey,
+            $modal = $(element),
+            $message = $modal.find('#session-warning-message'),
+            originalMessage = $message.text();
+
+        /**
+         * Initialize and configure the session expiry warning modal
+         */
+        function initSessionWarningModal() {
+            const options = {
+                type: 'popup',
+                innerScroll: true,
+                title: $t('Session Expiring Soon'),
+                modalClass: 'modal-admintimeout',
+                buttons: [
+                    {
+                        text: $t('Extend Session'),
+                        class: 'action-primary',
+                        click: function () {
+                            extendSession(this);
+                        }
+                    },
+                    {
+                        text: $t('Close'),
+                        class: 'action-secondary',
+                        click: function () {
+                            this.closeModal();
+                        }
+                    }
+                ]
+            };
+
+            modal(options, $modal);
+        }
+
+        /**
+         * Schedule the session warning modal to appear
+         */
+        function scheduleSessionWarning() {
+            // Clear any existing timeout
+            if (sessionTimeoutHandle) {
+                clearTimeout(sessionTimeoutHandle);
+            }
+
+            // Calculate delay: (sessionLifetime - warningOffset) * 1000 milliseconds
+            const delay = (sessionLifetime - warningOffset) * 1000;
+
+            sessionTimeoutHandle = setTimeout(function () {
+                $modal.modal('openModal');
+            }, delay);
+        }
+
+        /**
+         * Extend the admin session via AJAX
+         *
+         * @param {Object} modalContext - The modal instance context
+         */
+        function extendSession(modalContext) {
+            // Show loading state
+            $message.text($t('Extending your session...'));
+
+            $.ajax({
+                url: extendSessionUrl,
+                type: 'POST',
+                dataType: 'json',
+                data: {
+                    form_key: formKey
+                },
+                success: function (response) {
+                    if (response.success) {
+                        // Show a success message
+                        $message.text($t('Session extended successfully!'));
+
+                        // Close modal after a short delay
+                        setTimeout(function () {
+                            modalContext.closeModal();
+                            $message.text(originalMessage);
+
+                            // Reschedule the warning modal
+                            scheduleSessionWarning();
+                        }, 1500);
+                    } else {
+                        // Show error message
+                        $message.text(response.message || $t('Failed to extend session. Please try again.'));
+
+                        // Restore the original message after delay
+                        setTimeout(function () {
+                            $message.text(originalMessage);
+                        }, 3000);
+                    }
+                },
+                error: function () {
+                    // Show error message
+                    $message.text($t('An error occurred. Please refresh the page.'));
+
+                    // Restore the original message after delay
+                    setTimeout(function () {
+                        $message.text(originalMessage);
+                    }, 3000);
+                }
+            });
+        }
+
+        // Initialise modal and schedule warning
+        initSessionWarningModal();
+        scheduleSessionWarning();
+    };
+});


### PR DESCRIPTION
**Description of the proposed changes**
Closing #16 

In release 1.3.0, a session expiry warning modal was introduced. However, because the modal is not hidden via CSS, it can cause CLS issues (it flashes briefly on page load).

These changes resolve this issue by:
- Securely rendering a style tag, setting `display:none` on the modal
- Moving inline styling to `_module.less`
- Moving inline JS to a separate file and using `x-magento-init` to initialise

The latter two changes are not required for the fix, but are for conforming to Magento coding standards

Notes to reviewers

ℹ️ When you've finished leaving feedback, please add a final comment to the PR tagging the author, letting them know that you have finished leaving feedback

