### PR TITLE
Feature/beg 231 session modal enhancements

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -14,6 +14,8 @@ jobs:
       - uses: actions/checkout@v2
       - uses: graycoreio/github-actions-magento2/supported-version@main
         id: supported-version
+        with:
+          include_services: true
       - run: echo ${{ steps.supported-version.outputs.matrix }}
   integration-workflow:
     needs: compute_matrix

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -7,13 +7,14 @@ on:
 
 jobs:
   compute_matrix:
-      runs-on: ubuntu-latest
-      outputs:
-        matrix: ${{ steps.supported-version.outputs.matrix }}
-      steps:
-        - uses: graycoreio/github-actions-magento2/supported-version@main
-          id: supported-version
-        - run: echo ${{ steps.supported-version.outputs.matrix }}
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.supported-version.outputs.matrix }}
+    steps:
+      - uses: actions/checkout@v2
+      - uses: graycoreio/github-actions-magento2/supported-version@main
+        id: supported-version
+      - run: echo ${{ steps.supported-version.outputs.matrix }}
   integration-workflow:
     needs: compute_matrix
     uses: graycoreio/github-actions-magento2/.github/workflows/integration.yaml@main

--- a/ViewModel/Modal.php
+++ b/ViewModel/Modal.php
@@ -59,4 +59,14 @@ class Modal implements ArgumentInterface
     {
         return $this->backendUrl->getUrl('pci4/session/extendsession');
     }
+
+    /**
+     * Get admin login page URL
+     *
+     * @return string
+     */
+    public function getLoginUrl(): string
+    {
+        return $this->backendUrl->getUrl('adminhtml/auth/login');
+    }
 }

--- a/view/adminhtml/templates/modal.phtml
+++ b/view/adminhtml/templates/modal.phtml
@@ -35,7 +35,8 @@ $extendSessionUrl = $viewModel->getExtendSessionUrl();
             "Aligent_Pci4Compatibility/js/session-expiry-warning": {
                 "sessionLifetime": <?= /* @noEscape */ (int)$sessionLifetime ?>,
                 "extendSessionUrl": "<?= $escaper->escapeUrl($extendSessionUrl) ?>",
-                "formKey": "<?= $escaper->escapeJs($block->getFormKey()) ?>"
+                "formKey": "<?= $escaper->escapeJs($block->getFormKey()) ?>",
+                "loginUrl": "<?= $escaper->escapeUrl($viewModel->getLoginUrl()) ?>"
             }
         }
     }

--- a/view/adminhtml/web/css/source/_module.less
+++ b/view/adminhtml/web/css/source/_module.less
@@ -5,3 +5,10 @@
         color: #ff0000;
     }
 }
+
+.modal-admintimeout.session-expired {
+    .action-secondary,
+    .action-close {
+        display: none !important;
+    }
+}

--- a/view/adminhtml/web/js/session-expiry-warning.js
+++ b/view/adminhtml/web/js/session-expiry-warning.js
@@ -5,6 +5,17 @@ define([
 ], function ($, modal, $t) {
     'use strict';
 
+    const STORAGE_KEY = 'aligent_session_expiry';
+
+    function getSessionExpiry() {
+        const stored = localStorage.getItem(STORAGE_KEY);
+        return stored ? parseInt(stored, 10) : null;
+    }
+
+    function setSessionExpiry(timestamp) {
+        localStorage.setItem(STORAGE_KEY, timestamp.toString());
+    }
+
     return function (config, element) {
         let sessionTimeoutHandle = null,
             countdownHandle = null,
@@ -50,24 +61,55 @@ define([
         }
 
         /**
+         * Reset the modal UI back to the pre-expiry warning state
+         */
+        function resetModalState() {
+            const $modalWrapper = $modal.closest('.modal-admintimeout'),
+                modalInstance = $modal.data('mage-modal');
+
+            $message.text(originalMessage);
+            $modalWrapper.find('.modal-title').text($t('Session Expiring Soon'));
+            $modalWrapper.find('.action-primary span').text($t('Extend Session'));
+            $modalWrapper.removeClass('session-expired');
+
+            if (modalInstance && modalInstance.options.keyEventHandlers && originalEscapeHandler) {
+                modalInstance.options.keyEventHandlers.escapeKey = originalEscapeHandler;
+                originalEscapeHandler = null;
+            }
+
+            sessionExpired = false;
+        }
+
+        /**
+         * Perform a single countdown tick, deriving remaining time from the stored expiry timestamp
+         */
+        function tickCountdown() {
+            const expiry = getSessionExpiry(),
+                remaining = expiry ? Math.max(0, Math.round((expiry - Date.now()) / 1000)) : 0;
+
+            if (remaining <= 0) {
+                if (countdownHandle) {
+                    clearInterval(countdownHandle);
+                    countdownHandle = null;
+                }
+
+                onSessionExpired();
+            } else {
+                updateCountdownMessage(remaining);
+            }
+        }
+
+        /**
          * Start the countdown timer displayed in the modal
          */
         function startCountdown() {
-            let remainingSeconds = warningOffset;
+            if (countdownHandle) {
+                clearInterval(countdownHandle);
+                countdownHandle = null;
+            }
 
-            updateCountdownMessage(remainingSeconds);
-
-            countdownHandle = setInterval(function () {
-                remainingSeconds--;
-
-                if (remainingSeconds <= 0) {
-                    clearInterval(countdownHandle);
-                    countdownHandle = null;
-                    onSessionExpired();
-                } else {
-                    updateCountdownMessage(remainingSeconds);
-                }
-            }, 1000);
+            tickCountdown();
+            countdownHandle = setInterval(tickCountdown, 1000);
         }
 
         /**
@@ -88,7 +130,7 @@ define([
         function onSessionExpired() {
             sessionExpired = true;
 
-            let $modalWrapper = $modal.closest('.modal-admintimeout'),
+            const $modalWrapper = $modal.closest('.modal-admintimeout'),
                 modalInstance = $modal.data('mage-modal');
 
             $message.text($t('Your session has expired. Please log in again to continue.'));
@@ -115,12 +157,13 @@ define([
         }
 
         /**
-         * Schedule the session warning modal to appear
+         * Schedule the session warning modal to appear, deriving timing from the stored expiry timestamp
          */
         function scheduleSessionWarning() {
             // Clear any existing timeout
             if (sessionTimeoutHandle) {
                 clearTimeout(sessionTimeoutHandle);
+                sessionTimeoutHandle = null;
             }
 
             // Clear any existing countdown
@@ -129,13 +172,27 @@ define([
                 countdownHandle = null;
             }
 
-            // Calculate delay: (sessionLifetime - warningOffset) * 1000 milliseconds
-            const delay = (sessionLifetime - warningOffset) * 1000;
+            const expiry = getSessionExpiry();
 
-            sessionTimeoutHandle = setTimeout(function () {
+            if (!expiry) {
+                return;
+            }
+
+            const remaining = expiry - Date.now(),
+                warningTime = warningOffset * 1000;
+
+            if (remaining <= 0) {
+                $modal.modal('openModal');
+                onSessionExpired();
+            } else if (remaining <= warningTime) {
                 $modal.modal('openModal');
                 startCountdown();
-            }, delay);
+            } else {
+                sessionTimeoutHandle = setTimeout(function () {
+                    $modal.modal('openModal');
+                    startCountdown();
+                }, remaining - warningTime);
+            }
         }
 
         /**
@@ -167,33 +224,15 @@ define([
                             countdownHandle = null;
                         }
 
-                        sessionExpired = false;
+                        setSessionExpiry(Date.now() + sessionLifetime * 1000);
 
                         // Show a success message
                         $message.text($t('Session extended successfully!'));
 
                         // Close modal after a short delay
                         setTimeout(function () {
-                            let $modalWrapper = $modal.closest('.modal-admintimeout'),
-                                modalInstance = $modal.data('mage-modal');
-
+                            resetModalState();
                             modalContext.closeModal();
-                            $message.text(originalMessage);
-
-                            // Reset modal title and button text
-                            $modalWrapper.find('.modal-title').text($t('Session Expiring Soon'));
-                            $modalWrapper.find('.action-primary span').text($t('Extend Session'));
-
-                            // Restore Close button and header X button
-                            $modalWrapper.removeClass('session-expired');
-
-                            // Restore Escape key handler
-                            if (modalInstance && modalInstance.options.keyEventHandlers && originalEscapeHandler) {
-                                modalInstance.options.keyEventHandlers.escapeKey = originalEscapeHandler;
-                                originalEscapeHandler = null;
-                            }
-
-                            // Reschedule the warning modal
                             scheduleSessionWarning();
                         }, 1500);
                     } else {
@@ -218,7 +257,72 @@ define([
             });
         }
 
-        // Initialise modal and schedule warning
+        // Cross-tab synchronization via storage event
+        $(window).on('storage', function (e) {
+            if (e.originalEvent.key !== STORAGE_KEY) {
+                return;
+            }
+
+            const newExpiry = parseInt(e.originalEvent.newValue, 10);
+
+            if (isNaN(newExpiry)) {
+                return;
+            }
+
+            if (sessionTimeoutHandle) {
+                clearTimeout(sessionTimeoutHandle);
+                sessionTimeoutHandle = null;
+            }
+
+            if (countdownHandle) {
+                clearInterval(countdownHandle);
+                countdownHandle = null;
+            }
+
+            const modalInstance = $modal.data('mage-modal'),
+                isOpen = modalInstance && modalInstance.options.isOpen;
+
+            if ((newExpiry - Date.now()) > warningOffset * 1000) {
+                if (isOpen) {
+                    resetModalState();
+                    modalInstance.closeModal();
+                }
+
+                scheduleSessionWarning();
+            } else if (newExpiry > Date.now()) {
+                if (!isOpen) {
+                    $modal.modal('openModal');
+                }
+
+                startCountdown();
+            } else {
+                if (!isOpen) {
+                    $modal.modal('openModal');
+                }
+
+                onSessionExpired();
+            }
+        });
+
+        // Background tab safety net — re-sync when tab becomes visible
+        document.addEventListener('visibilitychange', function () {
+            if (!document.hidden && !sessionExpired) {
+                scheduleSessionWarning();
+            }
+        });
+
+        // Detect admin AJAX activity that extends the PHP session
+        $(document).ajaxComplete(function (event, xhr) {
+            if (sessionExpired || !xhr || xhr.status < 200 || xhr.status >= 300) {
+                return;
+            }
+
+            setSessionExpiry(Date.now() + sessionLifetime * 1000);
+            scheduleSessionWarning();
+        });
+
+        // Initialize: set expiry timestamp (page load refreshes the server session) and start
+        setSessionExpiry(Date.now() + sessionLifetime * 1000);
         initSessionWarningModal();
         scheduleSessionWarning();
     };

--- a/view/adminhtml/web/js/session-expiry-warning.js
+++ b/view/adminhtml/web/js/session-expiry-warning.js
@@ -7,13 +7,17 @@ define([
 
     return function (config, element) {
         let sessionTimeoutHandle = null,
+            countdownHandle = null,
+            sessionExpired = false,
             sessionLifetime = config.sessionLifetime || 900,
             warningOffset = 60, // Show warning 60 seconds before expiry
             extendSessionUrl = config.extendSessionUrl,
             formKey = config.formKey,
+            loginUrl = config.loginUrl,
             $modal = $(element),
             $message = $modal.find('#session-warning-message'),
-            originalMessage = $message.text();
+            originalMessage = $message.text(),
+            originalEscapeHandler = null;
 
         /**
          * Initialize and configure the session expiry warning modal
@@ -46,6 +50,71 @@ define([
         }
 
         /**
+         * Start the countdown timer displayed in the modal
+         */
+        function startCountdown() {
+            let remainingSeconds = warningOffset;
+
+            updateCountdownMessage(remainingSeconds);
+
+            countdownHandle = setInterval(function () {
+                remainingSeconds--;
+
+                if (remainingSeconds <= 0) {
+                    clearInterval(countdownHandle);
+                    countdownHandle = null;
+                    onSessionExpired();
+                } else {
+                    updateCountdownMessage(remainingSeconds);
+                }
+            }, 1000);
+        }
+
+        /**
+         * Update the modal message with the remaining seconds
+         *
+         * @param {number} seconds
+         */
+        function updateCountdownMessage(seconds) {
+            $message.text(
+                $t('Your session will expire in %1 seconds. Please save your changes or extend your session to continue working.')
+                    .replace('%1', seconds)
+            );
+        }
+
+        /**
+         * Handle session expiry — update modal to expired state
+         */
+        function onSessionExpired() {
+            sessionExpired = true;
+
+            let $modalWrapper = $modal.closest('.modal-admintimeout'),
+                modalInstance = $modal.data('mage-modal');
+
+            $message.text($t('Your session has expired. Please log in again to continue.'));
+
+            // Update modal title
+            $modalWrapper.find('.modal-title').text($t('Session Expired'));
+
+            // Update primary button text
+            $modalWrapper.find('.action-primary span').text($t('Go to Login'));
+
+            // Hide Close button and header X button via CSS class
+            $modalWrapper.addClass('session-expired');
+
+            // Prevent Escape key from closing the modal
+            if (modalInstance && modalInstance.options.keyEventHandlers) {
+                originalEscapeHandler = modalInstance.options.keyEventHandlers.escapeKey;
+                modalInstance.options.keyEventHandlers.escapeKey = function () {};
+            }
+
+            // Prevent overlay click from closing the modal
+            if (modalInstance && modalInstance.overlay) {
+                modalInstance.overlay.off('click');
+            }
+        }
+
+        /**
          * Schedule the session warning modal to appear
          */
         function scheduleSessionWarning() {
@@ -54,11 +123,18 @@ define([
                 clearTimeout(sessionTimeoutHandle);
             }
 
+            // Clear any existing countdown
+            if (countdownHandle) {
+                clearInterval(countdownHandle);
+                countdownHandle = null;
+            }
+
             // Calculate delay: (sessionLifetime - warningOffset) * 1000 milliseconds
             const delay = (sessionLifetime - warningOffset) * 1000;
 
             sessionTimeoutHandle = setTimeout(function () {
                 $modal.modal('openModal');
+                startCountdown();
             }, delay);
         }
 
@@ -68,6 +144,11 @@ define([
          * @param {Object} modalContext - The modal instance context
          */
         function extendSession(modalContext) {
+            if (sessionExpired) {
+                window.location.href = loginUrl;
+                return;
+            }
+
             // Show loading state
             $message.text($t('Extending your session...'));
 
@@ -80,13 +161,37 @@ define([
                 },
                 success: function (response) {
                     if (response.success) {
+                        // Clear countdown
+                        if (countdownHandle) {
+                            clearInterval(countdownHandle);
+                            countdownHandle = null;
+                        }
+
+                        sessionExpired = false;
+
                         // Show a success message
                         $message.text($t('Session extended successfully!'));
 
                         // Close modal after a short delay
                         setTimeout(function () {
+                            let $modalWrapper = $modal.closest('.modal-admintimeout'),
+                                modalInstance = $modal.data('mage-modal');
+
                             modalContext.closeModal();
                             $message.text(originalMessage);
+
+                            // Reset modal title and button text
+                            $modalWrapper.find('.modal-title').text($t('Session Expiring Soon'));
+                            $modalWrapper.find('.action-primary span').text($t('Extend Session'));
+
+                            // Restore Close button and header X button
+                            $modalWrapper.removeClass('session-expired');
+
+                            // Restore Escape key handler
+                            if (modalInstance && modalInstance.options.keyEventHandlers && originalEscapeHandler) {
+                                modalInstance.options.keyEventHandlers.escapeKey = originalEscapeHandler;
+                                originalEscapeHandler = null;
+                            }
 
                             // Reschedule the warning modal
                             scheduleSessionWarning();


### PR DESCRIPTION
**Description of the proposed changes**
Fixes #18

Some small UX enhancements to the session extension popup:
- Instead of a static message, the popup will now contain a countdown from 60 seconds.
- Once the session has expired, the popup title and message reflect this.
- If the session has expired, the popup cannot be closed. The user must instead go to the login page.
- Cross-tab sharing of state via local storage. A session being extended in one tab will be reflected in others, etc.

**Screenshots (if applicable)**
Countdown timer:
<img width="1902" height="692" alt="image" src="https://github.com/user-attachments/assets/b546a607-19ac-415d-aefd-293d1c54deeb" />

Session expired message:
<img width="1905" height="631" alt="image" src="https://github.com/user-attachments/assets/ad3dac9c-4f6d-43ec-a0af-fd11c475a6bd" />

Synchronised state across tabs:
<img width="1905" height="599" alt="image" src="https://github.com/user-attachments/assets/ee393221-ba6f-4331-bd84-19a23610e138" />


**Other solutions considered (if any)**
Part of #18 relates to being able to log in again when the session has expired, without losing work. This is a much more complicated issue, and will be considered separately.


**Notes to reviewers**

ℹ️ When you've finished leaving feedback, please add a final comment to the PR tagging the author, letting them know that you have finished leaving feedback

