### PR TITLE
BEG-232 - Increase z-index of session expiry modal

### DIFF
--- a/view/adminhtml/web/css/source/_module.less
+++ b/view/adminhtml/web/css/source/_module.less
@@ -12,3 +12,14 @@
         display: none !important;
     }
 }
+
+// Ensure session warning modal renders above PageBuilder and HugeRTE editor panels
+body._session-warning-active {
+    .modal-admintimeout {
+        z-index: 9999 !important;
+    }
+
+    .modals-overlay {
+        z-index: 9998 !important;
+    }
+}

--- a/view/adminhtml/web/js/session-expiry-warning.js
+++ b/view/adminhtml/web/js/session-expiry-warning.js
@@ -39,6 +39,12 @@ define([
                 innerScroll: true,
                 title: $t('Session Expiring Soon'),
                 modalClass: 'modal-admintimeout',
+                opened: function () {
+                    $('body').addClass('_session-warning-active');
+                },
+                closed: function () {
+                    $('body').removeClass('_session-warning-active');
+                },
                 buttons: [
                     {
                         text: $t('Extend Session'),


### PR DESCRIPTION
**Description of the proposed changes**
Fixes #21 

The default z-index used by Magento modals is 900. However, some elements used in PageBuilder, TinyMCE, HugeRTE are above this. To ensure the session popup is in front of "everything" (not literally everything, but should be sufficient), we can apply a custom z-index of 9999 (and 9998 for the modal overlay).

**Screenshots (if applicable)**
Before:
<img width="3437" height="2046" alt="image" src="https://github.com/user-attachments/assets/a4705572-9632-4181-a1e1-6f031c59b569" />

After:
<img width="3401" height="1836" alt="image" src="https://github.com/user-attachments/assets/b1b64ce3-2d38-40f0-bfe2-ad96fa310581" />

**Other solutions considered (if any)**
It's not possible to ensure the popup is in front of every possible element, since 3rd-party modules could apply their own z-index values of whatever they want. In the event that a 3rd-party module is interfering with the popup's visibility, it is recommended to apply a patch or overwrite of `_module.less` to increase the z-index further.

**Notes to reviewers**

ℹ️ When you've finished leaving feedback, please add a final comment to the PR tagging the author, letting them know that you have finished leaving feedback

